### PR TITLE
close #24 fixing duplicate <title>

### DIFF
--- a/wp-content/themes/wp-rio/header.php
+++ b/wp-content/themes/wp-rio/header.php
@@ -12,7 +12,6 @@
 <html class="no-js" <?php language_attributes(); ?>>
 <head>
     <meta charset="UTF-8">
-    <title><?php wp_title(); ?></title>
     <?php wp_head(); ?>
     <meta name="google-site-verification" content="9Ms0xe7SDf46KRJFPVCpyZpXu_MBKedoBR8Quf1bPzc" />
     <script>


### PR DESCRIPTION
No Odin tava habilitando a opção `title-tag`.
Como o WordPress a partir da versão 4.1 sugere o uso dessa opção eu removi o a tag `<title>` do header.php e deixei a opção `title-tag` habilitada no functions.php conforme já vem por padrão no odin.
