### PR TITLE
Workaround para bug no pdf.js do Firefox

### DIFF
--- a/wp-content/themes/wp-rio/inc/certificate/css/certificate.css
+++ b/wp-content/themes/wp-rio/inc/certificate/css/certificate.css
@@ -8,7 +8,7 @@ body {
 .certificate {
 	width: 1024px;
 	height: 768px;
-	background: url('../img/certificado-bg.jpg') no-repeat center center;
+	background: url('../img/certificado-bg.jpg') center center;
 	margin: 20px auto 0;
 }
 


### PR DESCRIPTION
O certificado gerado no PDF está aparecendo assim:

![screenshot from 2015-09-23 10 10 53](https://cloud.githubusercontent.com/assets/4602525/10056467/b46341ec-6211-11e5-8a24-4c02d92cbd2c.png)

Quando o mpdf gera um pdf a partir de um HTML que tenha imagem com `background: no-repeat`,  um bug no `pdf.js` do Firefox impede que seja exibido corretamente (outros programas exibem normalmente).

O workaround é remover o `no-repeat` do CSS, nesse caso sem prejuízo algum para o PDF gerado
