### PR TITLE
Set true para crop das thumbs

### DIFF
--- a/wp-content/themes/wp-rio/functions.php
+++ b/wp-content/themes/wp-rio/functions.php
@@ -166,10 +166,10 @@ if ( ! function_exists( 'odin_setup_features' ) ) {
 		/*
 		 * Image sizes for cropping
 		 */
-		add_image_size( 'entry-thumb', 300, 225, array( 'center', 'center' ) );
-		add_image_size( 'entry-large', 940, 350, array( 'center', 'center' ) );
-		add_image_size( 'partners-thumb', 220, 165, array( 'center', 'center' ) );
-		add_image_size( 'organizer-thumb', 220, 290, array( 'center', 'center' ) );
+		add_image_size( 'entry-thumb', 300, 225, array( 'center', 'center', 'true' ) );
+		add_image_size( 'entry-large', 940, 350, array( 'center', 'center', 'true' ) );
+		add_image_size( 'partners-thumb', 220, 165, array( 'center', 'center', 'true' ) );
+		add_image_size( 'organizer-thumb', 220, 290, array( 'center', 'center', 'true' ) );
 	}
 }
 


### PR DESCRIPTION
Setei 'true' para forçar o crop das thumbs, testei local e ajustou todas as thumbs.
Depois que fizer o deploy desta alteração é preciso passar um Regenerate Thumbnails.

Obs: O Post 'Galeria de fotos do WordCamp RJ 2015' está setado com uma imagem com largura inferior.
